### PR TITLE
docs(notebooks): remove `quantum-enablement` imports in `scaling-sampler`

### DIFF
--- a/docs/notebooks/scaling-sampler/requirements.txt
+++ b/docs/notebooks/scaling-sampler/requirements.txt
@@ -1,4 +1,3 @@
-quantum-enablement @ git+https://github.com/IBM-Quantum-Technical-Enablement/quantum-enablement
 qiskit[visualization] >= 1.0.0
 qiskit-ibm-runtime >= 0.19.1
 prototype-zne >= 1.3.1


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
Removes imported functions from `quantum-enablement` repository in `scaling-sampler` notebook


### Details and comments
The following ara now defined in the notebook itself along with all needed auxiliary functions:
- `QAOAPathCircuit`
- `MBLChainCircuit`
- `TwoQubitPauliTwirlPass`

